### PR TITLE
Added IAM:PassRole to the CreateBranch and DeleteBranch functions to …

### DIFF
--- a/cdk_pipelines_multi_branch/cicd/iam_stack.py
+++ b/cdk_pipelines_multi_branch/cicd/iam_stack.py
@@ -81,6 +81,8 @@ class IAMPipelineStack(Construct):
                 }
             }
         ))
+        code_build_role.grant_pass_role(create_branch_role)
+        code_build_role.grant_pass_role(delete_branch_role)
 
         self.create_branch_role = create_branch_role
         self.delete_branch_role = delete_branch_role


### PR DESCRIPTION
…fix an issue with build/delete on branch

*Issue #, if available:*
Not tracked yet, but was receiving the following: 

`[ERROR]	2022-08-28T23:50:47.300Z	e2b85c4b-0586-4f82-a7fa-ec4d9a6fe72a	An error occurred (AccessDeniedException) when calling the CreateProject operation: User: arn:aws:sts::XX:assumed-role/cdk-pipelines-multi-branc-IAMPipelineLambdaCreateB-ZSTRO2FYNUZ8/LambdaTriggerCreateBranch is not authorized to perform: iam:PassRole on resource: arn:aws:iam::XX:role/cdk-pipelines-multi-branc-IAMPipelineCodeBuildExec-YJBU17LTTQ0G because no identity-based policy allows the iam:PassRole action`


*Description of changes:*
* Added grant_pass_role() to both the `create_branch_role` and `delete_branch_role`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
Yes